### PR TITLE
Fixing a race condition in the unit tests.  The number of active data…

### DIFF
--- a/src/test/java/net/tgburrin/dasit/DatasetServiceTest.java
+++ b/src/test/java/net/tgburrin/dasit/DatasetServiceTest.java
@@ -80,7 +80,7 @@ public class DatasetServiceTest extends BaseIntegrationTest {
 
 	@Test
 	public void addDataset() throws Exception {
-		Group ownerGroup = appService.findGroupByName("testgroup2");
+		Group ownerGroup = appService.findGroupByName("testgroup7");
 		Dataset newDs = new Dataset("", ownerGroup);
 
 		assertThrows(InvalidDataException.class, () -> {

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -8,7 +8,8 @@ values
 (3, 'testgroup3', 'deprecatedgroup@email.com', 'ACTIVE'),
 (4, 'testgroup4', 'inactivegroup@email.com', 'INACTIVE'),
 (5, 'standAloneGroup1', 'another@email.com', 'ACTIVE'),
-(6, 'testgroup6', 'testgroup6@email.com', 'ACTIVE')
+(6, 'testgroup6', 'testgroup6@email.com', 'ACTIVE'),
+(7, 'testgroup7', 'testgroup7@email.com', 'ACTIVE')
 ;
 
 insert into dasit.datasets (id, name, owner_group, status)


### PR DESCRIPTION
…sets could vary depending on when another test was run.